### PR TITLE
Bug Fix: DependsOn property

### DIFF
--- a/sagemaker_studio_template.yaml
+++ b/sagemaker_studio_template.yaml
@@ -88,6 +88,7 @@ Resources:
 
   StudioDomainFunction:
     Type: AWS::Lambda::Function
+    DependsOn: LambdaExecutionPolicy
     Properties:
       Handler: domain_function.lambda_handler
       Role: !GetAtt LambdaExecutionRole.Arn
@@ -98,7 +99,6 @@ Resources:
       Timeout: 900
       Layers:
         - !Ref CfnResponseLayer
-      DependsOn: LambdaExecutionPolicy
 
   CfnResponseLayer:
     Type: AWS::Lambda::LayerVersion


### PR DESCRIPTION
*Issue #, if available:*
Not available

*Description of changes:*
DependsOn property should be outside the context of Properties. The current CF template as such when checked out is not working and cloud formation keeps throwing error. Changing the context of DependsOn fixes it.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
